### PR TITLE
permanent_redirects.map: set up to try to truly redirect /webclient/default.aspx

### DIFF
--- a/permanent_redirects.map
+++ b/permanent_redirects.map
@@ -104,3 +104,5 @@
 "/docs/worldwidetelescopeexceladdin.html" "https://worldwidetelescope.github.io/#documentation";
 "/docs/worldwidetelescopelocalizationtool.html" "https://worldwidetelescope.github.io/#documentation";
 "/docs/wwtsdkfactsheet.pdf" "https://worldwidetelescope.github.io/#documentation";
+
+"/webclient/default.aspx" "/webclient/";


### PR DESCRIPTION
It turns out that things like the ShowImage.aspx API redirect here, so we're going to need a true server redirect.