### PR TITLE
Revert "permanent_redirects.map: set up to try to truly redirect /webclient/default.aspx"

### DIFF
--- a/permanent_redirects.map
+++ b/permanent_redirects.map
@@ -104,5 +104,3 @@
 "/docs/worldwidetelescopeexceladdin.html" "https://worldwidetelescope.github.io/#documentation";
 "/docs/worldwidetelescopelocalizationtool.html" "https://worldwidetelescope.github.io/#documentation";
 "/docs/wwtsdkfactsheet.pdf" "https://worldwidetelescope.github.io/#documentation";
-
-"/webclient/default.aspx" "/webclient/";


### PR DESCRIPTION
This reverts commit 1c7269a873c5bf4ad379ce5a5d3314d172907448.

I couldn't find a way to get the Azure Application Gateway to route the request to this path to the nginx server while still letting the static files backend handle `/webclient/*`, even though some of the V2 docs suggest this should be possible. I ended up taking another approach, using a JS redirect in the `default.aspx` provided in `wwt-web-client`.