### PR TITLE
permanent_redirects.map: add redirects for URLs removed from the user-facing website

### DIFF
--- a/permanent_redirects.map
+++ b/permanent_redirects.map
@@ -104,3 +104,20 @@
 "/docs/worldwidetelescopeexceladdin.html" "https://docs.worldwidetelescope.org/";
 "/docs/worldwidetelescopelocalizationtool.html" "https://docs.worldwidetelescope.org/";
 "/docs/wwtsdkfactsheet.pdf" "https://docs.worldwidetelescope.org/";
+
+"/getinvolved" "https://worldwidetelescope.org/connect/";
+"/getinvolved/" "https://worldwidetelescope.org/connect/";
+"/getinvolved/develop" "https://worldwidetelescope.github.io/";
+"/getinvolved/greatobservatories" "https://worldwidetelescope.github.io/#example-code";
+"/getinvolved/helpothers" "https://worldwidetelescope.org/connect/";
+"/getinvolved/importimage" "https://worldwidetelescope.github.io/#example-code";
+"/getinvolved/planetexplorer" "https://worldwidetelescope.github.io/#example-code";
+"/getinvolved/spectrum" "https://worldwidetelescope.github.io/#example-code";
+
+"/support" "https://worldwidetelescope.org/connect/";
+"/support/" "https://worldwidetelescope.org/connect/";
+"/support/issuesandbugs" "https://worldwidetelescope.org/connect/";
+"/support/localization" "https://worldwidetelescope.org/connect/";
+
+"/upgrade" "https://worldwidetelescope.org/download/";
+"/upgrade/" "https://worldwidetelescope.org/download/";


### PR DESCRIPTION
Not including paths like `/learn` where we're still serving some of the files, so that we need to have the Zola redirect them. (Well, we could handle them here if we wanted to write really detailed path-based routing rules for the App Gateway, but that bit isn't automated right now so I don't want to do anything too finicky there.)