### PR TITLE
Set up a redirection to the latest available installer

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -94,6 +94,10 @@ http {
       rewrite ^ "$redir_prefix$rw_perm_path" permanent;
     }
 
+    if ($rw_temp_path ~ "http") {
+      rewrite ^ "$rw_temp_path" redirect;
+    }
+
     if ($rw_temp_path != "none") {
       rewrite ^ "$redir_prefix$rw_temp_path" redirect;
     }

--- a/temporary_redirects.map
+++ b/temporary_redirects.map
@@ -1,1 +1,2 @@
+"/support/wwtsetup-latest.msi" "https://web.wwtassets.org/releases/wwt/wwtsetup-6.0.11.msi";
 "/webclient" "/webclient/";

--- a/temporary_redirects.map
+++ b/temporary_redirects.map
@@ -1,2 +1,2 @@
-"/support/wwtsetup-latest.msi" "https://web.wwtassets.org/releases/wwt/wwtsetup-6.0.11.msi";
+"/support/wwtsetup-latest.msi" "https://web.wwtassets.org/releases/wwt/wwtsetup-6.0.901.0.msi";
 "/webclient" "/webclient/";


### PR DESCRIPTION
It will live at https://worldwidetelescope.org/support/wwtsetup-latest.msi . The URL choice is a bit awkward to allow us to plug into this nginx framework without futzing with any of the cloud configuration.