### PR TITLE
temporary_redirects.map: update installer to 6.0.904.0

### DIFF
--- a/temporary_redirects.map
+++ b/temporary_redirects.map
@@ -1,2 +1,2 @@
-"/support/wwtsetup-latest.msi" "https://web.wwtassets.org/releases/wwt/wwtsetup-6.0.902.0.msi";
+"/support/wwtsetup-latest.msi" "https://web.wwtassets.org/releases/wwt/wwtsetup-6.0.904.0.msi";
 "/webclient" "/webclient/";


### PR DESCRIPTION
We're skipping 6.0.903 since I needed to make two releases in a row to be able to test the auto-update functionality, and there isn't anything useful gained by setting them up individually here.