### PR TITLE
temporary_redirects.map: update Windows to 6.0.906.0

### DIFF
--- a/temporary_redirects.map
+++ b/temporary_redirects.map
@@ -1,2 +1,2 @@
-"/support/wwtsetup-latest.msi" "https://web.wwtassets.org/releases/wwt/wwtsetup-6.0.904.0.msi";
+"/support/wwtsetup-latest.msi" "https://web.wwtassets.org/releases/wwt/wwtsetup-6.0.906.0.msi";
 "/webclient" "/webclient/";


### PR DESCRIPTION
As before, skipping 6.0.905.0 to test auto-update.